### PR TITLE
2606b: Add custom definition for YSWS

### DIFF
--- a/Airspace.xml
+++ b/Airspace.xml
@@ -7817,6 +7817,7 @@ CH VOR
     <Point Name="YN903" Type="Fix">-003625.650+1665921.199</Point>
     <Point Name="YOGIT" Type="Fix">-375052.102+1751505.400</Point>
     <Point Name="YPONT" Type="Fix">-442947.101+1674858.201</Point>
+    <Point Name="YSWS" Type="Fix">-335327.000+1504306.000</Point>
     <Point Name="YTUNA" Type="Fix">-462454.749+1683538.191</Point>
     <Point Name="ZADMO" Type="Fix">-895304.549-1514148.548</Point>
     <Point Name="ZEDEE" Type="Fix">-352139.488+1735226.141</Point>

--- a/Profile.xml
+++ b/Profile.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Profile Name="VATNZ Combined Oceanic" FullName="VATNZ Combined Oceanic (NZZO/NZCM/NTTT)">
-  <Version AIRAC="2511" Revision="c" PublishDate="20251101" UpdateURL="https://vatsys.sawbe.com/downloads/data/VATNZ%20Combined%20Oceanic" />
+  <Version AIRAC="2511" Revision="d" PublishDate="20260710" UpdateURL="https://vatsys.sawbe.com/downloads/data/VATNZ%20Combined%20Oceanic" />
   <Servers>
     <VATSIMStatus url="https://status.vatsim.net/" />
     <GRIB url="https://sawbe.com/GRIB/" />


### PR DESCRIPTION
Follows a reported bug where YSWS ADES is amended to `ZZZZ` due to not being able to find the ADES in the profile's `Intersections` dictionary (built from the Profile), or in the fallback `navigraphIntersections` lookup.